### PR TITLE
pro: link against libsodium on Linux /monero-gui#1540

### DIFF
--- a/aeon-wallet-gui.pro
+++ b/aeon-wallet-gui.pro
@@ -116,6 +116,7 @@ LIBS += -L$$WALLET_ROOT/lib \
         -lepee \
         -lunbound \
         -leasylogging \
+        -lsodium \
 }
 
 android {


### PR DESCRIPTION
This is needed to link against libmonero_wallet from monero
with PR #4159 merged.

Not touching other platforms because can't test.