### PR TITLE
Add libwinscard to link line on Windows /monero-gui#1444

### DIFF
--- a/aeon-wallet-gui.pro
+++ b/aeon-wallet-gui.pro
@@ -245,6 +245,7 @@ win32 {
         -lssl \
         -lcrypto \
         -Wl,-Bdynamic \
+        -lwinscard \
         -lws2_32 \
         -lwsock32 \
         -lIphlpapi \


### PR DESCRIPTION
This fixes monero-wallet-gui linking error in MSYS2 since PC/SC hw device support was added to Windows builds