### PR TITLE
Force use OSX 11 for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-macos:
 
-    runs-on: macOS-latest
+    runs-on: macOS-11
     
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Update MacOS CI to use Big Sur (11.6.2 currently) over Catalina. Currently the macos-latest still uses 10.15 and binaries may not execute properly on BigSur which is required for future updates for Mac ARM integration of QT wallet of Aeon. The timeline for the final integration of CI for Big Sur is unknown but this will force the use of Big Sur indefinitely until an update is needed for future OS.